### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
       - development
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/searledan/template-web/security/code-scanning/1](https://github.com/searledan/template-web/security/code-scanning/1)

In general, the fix is to add a `permissions` block that explicitly restricts the `GITHUB_TOKEN` to the minimal access needed. For this workflow, steps only read repository contents and interact with caches and artifacts, which do not require repository write access. Therefore, granting `contents: read` at the workflow (top) level is an appropriate minimal configuration.

The best fix without changing functionality is to add a `permissions:` section near the top level of `.github/workflows/test.yml`, just after the `name:` or `on:` block, so that it applies to all jobs that don’t override it. We’ll set `contents: read`, which is sufficient for `actions/checkout@v4` and compatible with the rest of the steps (`setup-node`, `cache`, `upload-artifact`, and `run` commands). No additional imports or external definitions are required, only this YAML addition.

Concretely: in `.github/workflows/test.yml`, insert:

```yml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 10, before line 11 in the provided snippet). This will satisfy CodeQL’s recommendation and enforce least-privilege token usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
